### PR TITLE
Add Position Style to InlineWidget Component

### DIFF
--- a/src/components/InlineWidget/InlineWidget.tsx
+++ b/src/components/InlineWidget/InlineWidget.tsx
@@ -27,7 +27,7 @@ const defaultStyles = {
   minWidth: "320px",
   height: "630px",
   position: "relative",
-};
+} as React.CSSProperties;
 
 class InlineWidget extends React.Component<Props> {
   private readonly widgetParentContainerRef: React.RefObject<HTMLDivElement>;

--- a/src/components/InlineWidget/InlineWidget.tsx
+++ b/src/components/InlineWidget/InlineWidget.tsx
@@ -26,6 +26,7 @@ export interface InlineWidgetOptions {
 const defaultStyles = {
   minWidth: "320px",
   height: "630px",
+  position: "relative",
 };
 
 class InlineWidget extends React.Component<Props> {


### PR DESCRIPTION
Adding the style `position: "relative"` to the default styles of the InlineWidget component:

```
const defaultStyles = {
  minWidth: "320px",
  height: "630px",
  position: "relative",
} as React.CSSProperties;
```

To fix an issue where the loader is positioned under the embed for larger screen sizes, and to resolve the open [Infinitely Loading Widget](https://github.com/tcampb/react-calendly/issues/20) issue.

––
Other references:
[Stackoverflow post](https://stackoverflow.com/questions/63815946/react-calendly-package-infinitely-loading)