### PR TITLE
Hide Spinner Upon Frame Load Completion

### DIFF
--- a/src/calendly-widget.ts
+++ b/src/calendly-widget.ts
@@ -419,7 +419,15 @@ export default () => (
             (this.node.src = this.getSource()),
             (this.node.width = "100%"),
             (this.node.height = "100%"),
-            (this.node.frameBorder = "0")
+            (this.node.frameBorder = "0"),
+            (this.node.onload = function () {
+              var calendlySpinnerElement = document.querySelector(
+                ".calendly-spinner"
+              );
+              if (calendlySpinnerElement) {
+                calendlySpinnerElement.style.visibility = "hidden";
+              }
+            })
           );
         }),
         (t.prototype.inject = function () {


### PR DESCRIPTION
- Add function to calendly-widget that hides spinner/loader after the frame has finished loading