### PR TITLE
Dropped PopupText in favor of new PopupButton that renders a <button>.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ensure that React has been included into your page or component. Then, you can i
 
 - [InlineWidget](https://tcampb.github.io/react-calendly/?path=/story/components--inlinewidget)
 - [PopupWidget](https://tcampb.github.io/react-calendly/?path=/story/components--popupwidget)
-- [PopupText](https://tcampb.github.io/react-calendly/?path=/story/components--popuptext)
+- [PopupButton](https://tcampb.github.io/react-calendly/?path=/story/components--popupbutton)
 - [Custom Button](https://tcampb.github.io/react-calendly/?path=/story/components--custom-button)
 - [CalendlyEventListener](https://tcampb.github.io/react-calendly/?path=/story/components--calendlyeventlistener)
 

--- a/src/calendly-widget.ts
+++ b/src/calendly-widget.ts
@@ -291,7 +291,7 @@ export default () => (
       }),
       (window.Calendly.initPopupWidget = function (t) {
         return window.Calendly._util.domReady(function () {
-          return window.Calendly.showPopupWidget(t.url, "PopupText", t);
+          return window.Calendly.showPopupWidget(t.url, "PopupButton", t);
         });
       }),
       (window.Calendly.initInlineWidget = function (t) {
@@ -305,7 +305,7 @@ export default () => (
       (window.Calendly.showPopupWidget = function (t, e, n) {
         var o;
         return (
-          null == e && (e = "PopupText"),
+          null == e && (e = "PopupButton"),
           null == n && (n = {}),
           window.Calendly.closePopupWidget(),
           (o = function () {

--- a/src/calendly.tsx
+++ b/src/calendly.tsx
@@ -3,7 +3,7 @@ import initializeCalendly from "./calendly-widget";
 import { CALENDLY_STYLESHEET_SOURCE } from "./constants";
 
 import { InlineWidgetOptions } from "./components/InlineWidget/InlineWidget";
-import { PopupWidgetOptions } from "./components/PopupText/PopupText";
+import { PopupWidgetOptions } from "./components/PopupButton/PopupButton";
 
 export interface ICalendly {
   initInlineWidget(options: InlineWidgetOptions): void;

--- a/src/components/PopupButton/PopupButton.tsx
+++ b/src/components/PopupButton/PopupButton.tsx
@@ -29,13 +29,13 @@ const initWidget = (options: PopupWidgetOptions) => {
 };
 
 const createClickHandler = (widgetOptions: PopupWidgetOptions) => (
-  e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+  e: React.MouseEvent<HTMLButtonElement, MouseEvent>
 ) => {
   e.preventDefault();
   return initWidget(widgetOptions);
 };
 
-class PopupText extends React.Component<Props> {
+class PopupButton extends React.Component<Props> {
   componentWillUnmount() {
     window.Calendly.closePopupWidget();
   }
@@ -52,17 +52,15 @@ class PopupText extends React.Component<Props> {
       utm: this.props.utm,
     };
     return (
-      <a
-        href="#0"
-        role="button"
+      <button
         onClick={createClickHandler(widgetOptions)}
         style={this.props.styles || {}}
         className={this.props.className || ""}
       >
         {this.props.text}
-      </a>
+      </button>
     );
   }
 }
 
-export default PopupText;
+export default PopupButton;

--- a/src/components/PopupText/PopupText.tsx
+++ b/src/components/PopupText/PopupText.tsx
@@ -54,6 +54,7 @@ class PopupText extends React.Component<Props> {
     return (
       <a
         href="#0"
+        role="button"
         onClick={createClickHandler(widgetOptions)}
         style={this.props.styles || {}}
         className={this.props.className || ""}

--- a/src/components/PopupText/PopupText.tsx
+++ b/src/components/PopupText/PopupText.tsx
@@ -15,6 +15,7 @@ export interface Props {
   utm?: Utm;
   pageSettings?: PageSettings;
   styles?: React.CSSProperties | undefined;
+  className?: string;
 }
 
 export interface PopupWidgetOptions {
@@ -51,7 +52,12 @@ class PopupText extends React.Component<Props> {
       utm: this.props.utm,
     };
     return (
-      <a href="" onClick={createClickHandler(widgetOptions)} style={this.props.styles || {}}>
+      <a
+        href="#0"
+        onClick={createClickHandler(widgetOptions)}
+        style={this.props.styles || {}}
+        className={this.props.className || ""}
+      >
         {this.props.text}
       </a>
     );

--- a/src/components/stories/Components.stories.tsx
+++ b/src/components/stories/Components.stories.tsx
@@ -73,6 +73,7 @@ storiesOf("Components", module)
       utm={object("utm", utm)}
       pageSettings={object("pageSettings", pageSettings)}
       styles={object("styles", {})}
+      className={text("className", "")}
     />
   ))
   .add("PopupWidget", () => (
@@ -92,15 +93,24 @@ storiesOf("Components", module)
       url: text("url", "https://calendly.com/acmesales"),
       pageSettings: object("pageSettings", pageSettings),
       utm: object("utm", utm),
-      prefill: object("prefill", prefill)
-    }
+      prefill: object("prefill", prefill),
+    };
 
     return (
       <div>
-        <h4 style={{ textAlign: 'center' }}> Use the <code>openPopupWidget</code> function to create a custom button that will open the pop-up scheduler when clicked.</h4>
-        <button style={{ display: 'block', margin: '0 auto' }} onClick={() => openPopupWidget(options)}>Custom Button</button>
+        <h4 style={{ textAlign: "center" }}>
+          {" "}
+          Use the <code>openPopupWidget</code> function to create a custom
+          button that will open the pop-up scheduler when clicked.
+        </h4>
+        <button
+          style={{ display: "block", margin: "0 auto" }}
+          onClick={() => openPopupWidget(options)}
+        >
+          Custom Button
+        </button>
       </div>
-    )
+    );
   })
   .add("CalendlyEventListener", () => {
     const eventId = "calendly-event";
@@ -126,7 +136,9 @@ storiesOf("Components", module)
             >
               here
             </a>
-            {". You must specify your host in the iframe's src with the embed_domain parameter."}
+            {
+              ". You must specify your host in the iframe's src with the embed_domain parameter."
+            }
           </h4>
           <div>
             Calendly Event: <span id={eventId}></span>

--- a/src/components/stories/Components.stories.tsx
+++ b/src/components/stories/Components.stories.tsx
@@ -11,7 +11,7 @@ const {
 import { storiesOf } from "@storybook/react";
 import { withInfo } from "@storybook/addon-info";
 import InlineWidget from "../InlineWidget/InlineWidget";
-import PopupText from "../PopupText/PopupText";
+import PopupButton from "../PopupButton/PopupButton";
 import PopupWidget from "../PopupWidget/PopupWidget";
 import CalendlyEventListener from "../CalendlyEventListener/CalendlyEventListener";
 import { PageSettings, Utm, Prefill, openPopupWidget } from "../../calendly";
@@ -65,8 +65,8 @@ storiesOf("Components", module)
       pageSettings={object("pageSettings", pageSettings)}
     />
   ))
-  .add("PopupText", () => (
-    <PopupText
+  .add("PopupButton", () => (
+    <PopupButton
       url={text("url", "https://calendly.com/acmesales")}
       text={text("text", "Click here to schedule!")}
       prefill={object("prefill", prefill)}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
 import InlineWidget from "./components/InlineWidget/InlineWidget";
-import PopupText from "./components/PopupText/PopupText";
+import PopupButton from "./components/PopupButton/PopupButton";
 import PopupWidget from "./components/PopupWidget/PopupWidget";
 import CalendlyEventListener from "./components/CalendlyEventListener/CalendlyEventListener";
 import { openPopupWidget, closePopupWidget } from './calendly';
 
 export { InlineWidget };
-export { PopupText };
+export { PopupButton };
 export { PopupWidget };
 export { CalendlyEventListener };
 export { openPopupWidget, closePopupWidget };


### PR DESCRIPTION
This PR drops the `PopupText` that rendered a non-accessible anchor in favor of a new `PopupButton` that renders a `<button>` element that can be styled with both custom `className` and `styles` props.