### PR TITLE
Add guests property to prefill prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ prefill={{
   firstName: 'Jon',
   lastName: 'Snow',
   name: 'Jon Snow',
-  guests: 'janedoe@example.com,johndoe@example.com',
+  guests: [
+    'janedoe@example.com',
+    'johndoe@example.com'
+  ],
   customAnswers: {
     a1: 'a1',
     a2: 'a2',

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ prefill={{
   firstName: 'Jon',
   lastName: 'Snow',
   name: 'Jon Snow',
+  guests: 'janedoe@example.com,johndoe@example.com',
   customAnswers: {
     a1: 'a1',
     a2: 'a2',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-calendly",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Calendly integration for React apps",
   "author": "tcampb",
   "license": "MIT",

--- a/src/calendly-widget.ts
+++ b/src/calendly-widget.ts
@@ -508,14 +508,7 @@ export default () => (
           var t, e, n, o, i;
           if (!this.options.prefill) return null;
           if (
-            ((e = [
-              "name",
-              "firstName",
-              "lastName",
-              "email",
-              "location",
-              "guests",
-            ]),
+            ((e = ["name", "firstName", "lastName", "email", "location"]),
             (n = window.Calendly._util.snakeCaseKeys(
               window.Calendly._util.pick(this.options.prefill, e)
             )),
@@ -523,6 +516,13 @@ export default () => (
           ) {
             o = this.options.prefill.customAnswers;
             for (t in o) (i = o[t]), t.match(/^a\d{1,2}$/) && (n[t] = i);
+          }
+          if (
+            this.options.prefill.guests &&
+            Array.isArray(this.options.prefill.guests) &&
+            this.options.prefill.guests.length > 0
+          ) {
+            n["guests"] = this.options.prefill.guests.join(",");
           }
           return n;
         }),

--- a/src/calendly-widget.ts
+++ b/src/calendly-widget.ts
@@ -508,7 +508,14 @@ export default () => (
           var t, e, n, o, i;
           if (!this.options.prefill) return null;
           if (
-            ((e = ["name", "firstName", "lastName", "email", "location"]),
+            ((e = [
+              "name",
+              "firstName",
+              "lastName",
+              "email",
+              "location",
+              "guests",
+            ]),
             (n = window.Calendly._util.snakeCaseKeys(
               window.Calendly._util.pick(this.options.prefill, e)
             )),

--- a/src/calendly.tsx
+++ b/src/calendly.tsx
@@ -30,6 +30,7 @@ export type Prefill = Optional<{
   firstName: string;
   lastName: string;
   location: string;
+  guests: string;
   customAnswers: Optional<{
     a1: string;
     a2: string;

--- a/src/calendly.tsx
+++ b/src/calendly.tsx
@@ -30,7 +30,7 @@ export type Prefill = Optional<{
   firstName: string;
   lastName: string;
   location: string;
-  guests: string;
+  guests: string[];
   customAnswers: Optional<{
     a1: string;
     a2: string;

--- a/src/components/stories/Components.stories.tsx
+++ b/src/components/stories/Components.stories.tsx
@@ -21,6 +21,7 @@ const prefill: Prefill = {
   firstName: "Jon",
   lastName: "Snow",
   email: "test@test.com",
+  guests: "janedoe@example.com,johndoe@example.com",
   customAnswers: {
     a1: "a1",
     a2: "a2",

--- a/src/components/stories/Components.stories.tsx
+++ b/src/components/stories/Components.stories.tsx
@@ -21,7 +21,7 @@ const prefill: Prefill = {
   firstName: "Jon",
   lastName: "Snow",
   email: "test@test.com",
-  guests: "janedoe@example.com,johndoe@example.com",
+  guests: ["janedoe@example.com", "johndoe@example.com"],
   customAnswers: {
     a1: "a1",
     a2: "a2",


### PR DESCRIPTION
This PR allows adding `guests` property in the `prefill` prop.

It follows this guide from Calendly's help center: https://help.calendly.com/hc/en-us/articles/226766767-Pre-populate-invitee-information-on-the-scheduling-page