### PR TITLE
Ensure object props with same values do not cause a rerender

### DIFF
--- a/src/components/InlineWidget/InlineWidget.tsx
+++ b/src/components/InlineWidget/InlineWidget.tsx
@@ -132,9 +132,10 @@ class InlineWidget extends React.Component<Props> {
   private shouldWidgetUpdate(prevProps: Props) {
     return (
       prevProps.url !== this.props.url ||
-      prevProps.pageSettings !== this.props.pageSettings ||
-      prevProps.prefill !== this.props.prefill ||
-      prevProps.utm !== this.props.utm
+      ["pageSettings", "prefill", "utm"].some(
+        (prop) =>
+          JSON.stringify(prevProps[prop]) !== JSON.stringify(this.props[prop])
+      )
     );
   }
 }


### PR DESCRIPTION
We came across this bug at work where the `InlineWidget` was rerendering unnecessarily. This was causing the widget to reload when in our case we were dynamically changing the height of the widget on `onDateAndTimeSelected` and `onEventScheduled` but could happen theoretically on any component rerender. 

Reproducible Demo: 
https://codesandbox.io/s/inspiring-keldysh-fj3bl?file=/src/App.js

Object equality on rerenders will return true even if the values stay the same. That's why in the demo, if you change `prefill` and `pageSettings` to refs it doesn't cause a rerender/reload. 


