### PR TITLE
Make CalendlyEventListener event types accessible from the package

### DIFF
--- a/src/components/CalendlyEventListener/CalendlyEventListener.tsx
+++ b/src/components/CalendlyEventListener/CalendlyEventListener.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { CalendlyEvent } from "../../calendly";
 
-type DateAndTimeSelectedEvent = MessageEvent<{
+export type DateAndTimeSelectedEvent = MessageEvent<{
   event: CalendlyEvent.DATE_AND_TIME_SELECTED;
   payload: {};
 }>;
 
-type EventScheduledEvent = MessageEvent<{
+export type EventScheduledEvent = MessageEvent<{
   event: CalendlyEvent.EVENT_SCHEDULED;
   payload: {
     event: {
@@ -28,12 +28,12 @@ type EventScheduledEvent = MessageEvent<{
   };
 }>;
 
-type EventTypeViewedEvent = MessageEvent<{
+export type EventTypeViewedEvent = MessageEvent<{
   event: CalendlyEvent.EVENT_TYPE_VIEWED;
   payload: {};
 }>;
 
-type ProfilePageViewedEvent = MessageEvent<{
+export type ProfilePageViewedEvent = MessageEvent<{
   event: CalendlyEvent.PROFILE_PAGE_VIEWED;
   payload: {};
 }>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,22 @@ import InlineWidget from "./components/InlineWidget/InlineWidget";
 import PopupButton from "./components/PopupButton/PopupButton";
 import PopupWidget from "./components/PopupWidget/PopupWidget";
 import CalendlyEventListener from "./components/CalendlyEventListener/CalendlyEventListener";
+import type {
+  DateAndTimeSelectedEvent,
+  EventScheduledEvent,
+  EventTypeViewedEvent,
+  ProfilePageViewedEvent,
+} from "./components/CalendlyEventListener/CalendlyEventListener";
 import { openPopupWidget, closePopupWidget } from './calendly';
 
 export { InlineWidget };
 export { PopupButton };
 export { PopupWidget };
 export { CalendlyEventListener };
+export {
+  DateAndTimeSelectedEvent,
+  EventScheduledEvent,
+  EventTypeViewedEvent,
+  ProfilePageViewedEvent,
+};
 export { openPopupWidget, closePopupWidget };


### PR DESCRIPTION
I use my `Calendly` as a separate component now and would like to pass the props to `CalendlyEventListener`. This PR makes the typings accessible from the package.

```
import {
  InlineWidget,
  CalendlyEventListener,
} from 'react-calendly';
import {
  DateAndTimeSelectedEvent,
  EventScheduledEvent,
} from 'react-calendly/typings/components/CalendlyEventListener';

type Props = {
  onEventScheduled?: (e: EventScheduledEvent) => void;
  onDateAndTimeSelected?: (e: DateAndTimeSelectedEvent) => void;
};

const Calendly = ({ onEventScheduled, onDateAndTimeSelected }: Props) => {
  return (
    <>
      <InlineWidget url={CALENDLY_LINK} />

      <CalendlyEventListener
        onEventScheduled={onEventScheduled}
        onDateAndTimeSelected={onDateAndTimeSelected}
      />
    </>
  );
};
```