### PR TITLE
Support new React 18 types

### DIFF
--- a/src/components/CalendlyEventListener/CalendlyEventListener.tsx
+++ b/src/components/CalendlyEventListener/CalendlyEventListener.tsx
@@ -43,6 +43,7 @@ type Props = {
   onEventScheduled?: (e: EventScheduledEvent) => any;
   onEventTypeViewed?: (e: EventTypeViewedEvent) => any;
   onProfilePageViewed?: (e: ProfilePageViewedEvent) => any;
+  children?: React.ReactNode;
 };
 
 class CalendlyEventListener extends React.Component<Props> {


### PR DESCRIPTION
React 18 has removed the implicit children property:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210

This change still works with React types versions below 18.

Please consider this as using this component will not compile if you install the React 18 types.