### PR TITLE
Added phone number to prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ prefill={{
   firstName: 'Jon',
   lastName: 'Snow',
   name: 'Jon Snow',
+  phoneNumber: '+1234567890',
   guests: [
     'janedoe@example.com',
     'johndoe@example.com'

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ prefill={{
   firstName: 'Jon',
   lastName: 'Snow',
   name: 'Jon Snow',
-  phoneNumber: '+1234567890',
+  smsReminderNumber: '+1234567890',
   guests: [
     'janedoe@example.com',
     'johndoe@example.com'

--- a/src/calendly.tsx
+++ b/src/calendly.tsx
@@ -9,6 +9,7 @@ export type Prefill = Optional<{
   email: string;
   firstName: string;
   lastName: string;
+  phoneNumber: string;
   location: string;
   guests: string[];
   customAnswers: Optional<{
@@ -121,6 +122,7 @@ export const formatCalendlyUrl = ({
     guests,
     lastName,
     location,
+    phoneNumber,
     name,
   } = prefill;
 
@@ -147,6 +149,7 @@ export const formatCalendlyUrl = ({
     textColor ? `text_color=${textColor}` : null,
     hideGdprBanner ? `hide_gdpr_banner=1` : null,
     name ? `name=${encodeURIComponent(name)}` : null,
+    phoneNumber ? `phone_number=${encodeURIComponent(phoneNumber)}` : null,
     location ? `location=${encodeURIComponent(location)}` : null,
     firstName ? `first_name=${encodeURIComponent(firstName)}` : null,
     lastName ? `last_name=${encodeURIComponent(lastName)}` : null,

--- a/src/calendly.tsx
+++ b/src/calendly.tsx
@@ -9,7 +9,7 @@ export type Prefill = Optional<{
   email: string;
   firstName: string;
   lastName: string;
-  phoneNumber: string;
+  smsReminderNumber: string;
   location: string;
   guests: string[];
   customAnswers: Optional<{
@@ -122,7 +122,7 @@ export const formatCalendlyUrl = ({
     guests,
     lastName,
     location,
-    phoneNumber,
+    smsReminderNumber,
     name,
   } = prefill;
 
@@ -149,7 +149,7 @@ export const formatCalendlyUrl = ({
     textColor ? `text_color=${textColor}` : null,
     hideGdprBanner ? `hide_gdpr_banner=1` : null,
     name ? `name=${encodeURIComponent(name)}` : null,
-    phoneNumber ? `phone_number=${encodeURIComponent(phoneNumber)}` : null,
+    smsReminderNumber ? `phone_number=${encodeURIComponent(smsReminderNumber)}` : null,
     location ? `location=${encodeURIComponent(location)}` : null,
     firstName ? `first_name=${encodeURIComponent(firstName)}` : null,
     lastName ? `last_name=${encodeURIComponent(lastName)}` : null,


### PR DESCRIPTION
- Added phone number to prefill

Hi again @tcampb, I found that phone_number is a valid prefill field for calendly.
In my case is needed for my integration to work and I don't have access to the calendly config page to change it to a custom answer

Thanks.