### PR TITLE
Added persistent option and bounce animation

### DIFF
--- a/src/calendly-widget.css
+++ b/src/calendly-widget.css
@@ -56,6 +56,7 @@
     left:50%;
     -webkit-transform:translateY(-50%) translateX(-50%);
     transform:translateY(-50%) translateX(-50%);
+    transform-origin: center center;
     width:80%;
     min-width:900px;
     max-width:1000px;
@@ -190,4 +191,21 @@
         -webkit-transform:scale(1);
         transform:scale(1)
     }
+}
+
+.calendly-overlay--bounce .calendly-popup {
+  animation: calendly-bounce 0.3s ease-out;
+  transform-origin: center center;
+}
+
+@-webkit-keyframes calendly-bounce {
+  0% { -webkit-transform: translateY(-50%) translateX(-50%) scale(1); }
+  50% { -webkit-transform: translateY(-50%) translateX(-50%) scale(1.03); }
+  100% { -webkit-transform: translateY(-50%) translateX(-50%) scale(1); }
+}
+
+@keyframes calendly-bounce {
+  0% { transform: translateY(-50%) translateX(-50%) scale(1); }
+  50% { transform: translateY(-50%) translateX(-50%) scale(1.03); }
+  100% { transform: translateY(-50%) translateX(-50%) scale(1); }
 }

--- a/src/components/PopupButton/PopupButton.tsx
+++ b/src/components/PopupButton/PopupButton.tsx
@@ -14,6 +14,7 @@ export interface Props {
   className?: string;
   iframeTitle?: IframeTitle;
   LoadingSpinner?: LoadingSpinner;
+  persistent?: boolean;
 }
 
 class PopupButton extends React.Component<Props, { isOpen: boolean }> {
@@ -58,6 +59,7 @@ class PopupButton extends React.Component<Props, { isOpen: boolean }> {
           open={this.state.isOpen}
           onModalClose={this.onClose}
           rootElement={this.props.rootElement}
+          persistent={this.props.persistent}
         />
       </>
     );

--- a/src/components/PopupModal/Modal.tsx
+++ b/src/components/PopupModal/Modal.tsx
@@ -6,6 +6,7 @@ import ModalContent, { Props as ModalContentProps } from "./ModalContent";
 interface Props extends ModalContentProps {
   onModalClose: (e: React.MouseEvent<HTMLElement>) => void;
   open: boolean;
+  persistent: boolean;
   rootElement: HTMLElement;
   LoadingSpinner?: LoadingSpinner;
 }
@@ -20,7 +21,7 @@ export default (props: Props) => {
   return ReactDom.createPortal(
     <div className="calendly-overlay">
       <div
-        onClick={props.onModalClose}
+        onClick={!persistent && props.onModalClose}
         className="calendly-close-overlay"
       ></div>
       <div className="calendly-popup">

--- a/src/components/PopupModal/Modal.tsx
+++ b/src/components/PopupModal/Modal.tsx
@@ -6,40 +6,85 @@ import ModalContent, { Props as ModalContentProps } from "./ModalContent";
 interface Props extends ModalContentProps {
   onModalClose: (e: React.MouseEvent<HTMLElement>) => void;
   open: boolean;
-  persistent: boolean;
   rootElement: HTMLElement;
   LoadingSpinner?: LoadingSpinner;
+  persistent?: boolean;
 }
 
-export default (props: Props) => {
-  if (!props.open) return null;
+interface State {
+  isBouncing: boolean;
+}
 
-  if (!props.rootElement) {
-    throw new Error('[react-calendly]: PopupModal rootElement property cannot be undefined')
+class PopupModal extends React.Component<Props, State> {
+  private bounceTimeout: number | null = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isBouncing: false,
+    };
+    this.handleOverlayClick = this.handleOverlayClick.bind(this);
   }
 
-  return ReactDom.createPortal(
-    <div className="calendly-overlay">
+  componentWillUnmount() {
+    if (this.bounceTimeout) {
+      clearTimeout(this.bounceTimeout);
+    }
+  }
+
+  handleOverlayClick(e: React.MouseEvent<HTMLElement>) {
+    if (this.props.persistent) {
+      this.setState({ isBouncing: true });
+      if (this.bounceTimeout) {
+        clearTimeout(this.bounceTimeout);
+      }
+      this.bounceTimeout = setTimeout(() => {
+        this.setState({ isBouncing: false });
+        this.bounceTimeout = null;
+      }, 300);
+    } else {
+      this.props.onModalClose(e);
+    }
+  }
+
+  render() {
+    if (!this.props.open) return null;
+
+    if (!this.props.rootElement) {
+      throw new Error(
+        "[react-calendly]: PopupModal rootElement property cannot be undefined"
+      );
+    }
+
+    const { isBouncing } = this.state;
+
+    return ReactDom.createPortal(
       <div
-        onClick={!persistent && props.onModalClose}
-        className="calendly-close-overlay"
-      ></div>
-      <div className="calendly-popup">
-        <div className="calendly-popup-content">
-          <ModalContent {...props} />
+        className={`calendly-overlay ${isBouncing ? "calendly-overlay--bounce" : ""}`}
+      >
+        <div
+          onClick={this.handleOverlayClick}
+          className="calendly-close-overlay"
+        ></div>
+        <div className="calendly-popup">
+          <div className="calendly-popup-content">
+            <ModalContent {...this.props} />
+          </div>
         </div>
-      </div>
-      <button
-        className="calendly-popup-close"
-        onClick={props.onModalClose}
-        aria-label="Close modal"
-        style={{
-          display: "block",
-          border: "none",
-          padding: 0,
-        }}
-      ></button>
-    </div>,
-    props.rootElement
-  );
-};
+        <button
+          className="calendly-popup-close"
+          onClick={this.props.onModalClose}
+          aria-label="Close modal"
+          style={{
+            display: "block",
+            border: "none",
+            padding: 0,
+          }}
+        ></button>
+      </div>,
+      this.props.rootElement
+    );
+  }
+}
+
+export default PopupModal;

--- a/src/components/PopupWidget/PopupWidget.tsx
+++ b/src/components/PopupWidget/PopupWidget.tsx
@@ -15,6 +15,7 @@ export interface Props {
   pageSettings?: PageSettings;
   iframeTitle?: IframeTitle;
   LoadingSpinner?: LoadingSpinner;
+  persistent?: boolean;
 }
 
 class PopupWidget extends React.Component<Props, { isOpen: boolean }> {
@@ -61,6 +62,7 @@ class PopupWidget extends React.Component<Props, { isOpen: boolean }> {
           open={this.state.isOpen}
           onModalClose={this.onClose}
           rootElement={this.props.rootElement}
+          persistent={this.props.persistent}
         />
       </div>
     );


### PR DESCRIPTION
- Added persistent option/prop for the Modal so that developers can choose whether to allow the user to close the modal by clicking outside it.
- Added a bounce effect to the modal to indicate to the user that it is not possible (quite common practice).

Hi @tcampb ,
Thought this could be useful for the repo. Happened to need it for one of the projects I am working on.

Cheers



