### PR TITLE
Add className to InlineWidget and removes unused prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ prefill={{
   firstName: 'Jon',
   lastName: 'Snow',
   name: 'Jon Snow',
-  smsReminderNumber: '+1234567890',
   guests: [
     'janedoe@example.com',
     'johndoe@example.com'

--- a/src/calendly-widget.css
+++ b/src/calendly-widget.css
@@ -8,186 +8,194 @@
 .calendly-badge-widget *,
 .calendly-overlay,
 .calendly-overlay * {
-    font-size:16px;
-    line-height:1.2em
+  font-size: 16px;
+  line-height: 1.2em;
 }
 
-.calendly-inline-widget iframe,
+.calendly-inline-widget iframe {
+  min-width: 320px;
+  height: 630px;
+}
 .calendly-badge-widget iframe,
 .calendly-overlay iframe {
-    display:inline;
-    width:100%;
-    height:100%
+  display: inline;
+  width: 100%;
+  height: 100%;
 }
 
 .calendly-popup-content {
-    position:relative
+  position: relative;
 }
 
 .calendly-popup-content.calendly-mobile {
-    -webkit-overflow-scrolling:touch;
-    overflow-y:auto
+  -webkit-overflow-scrolling: touch;
+  overflow-y: auto;
 }
 
 .calendly-overlay {
-    position:fixed;
-    top:0;
-    left:0;
-    right:0;
-    bottom:0;
-    overflow:hidden;
-    z-index:9999;
-    background-color:#a5a5a5;
-    background-color:rgba(31,31,31,0.4)
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+  z-index: 9999;
+  background-color: #a5a5a5;
+  background-color: rgba(31, 31, 31, 0.4);
 }
 
 .calendly-overlay .calendly-close-overlay {
-    position:absolute;
-    top:0;
-    left:0;
-    right:0;
-    bottom:0
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .calendly-overlay .calendly-popup {
-    box-sizing:border-box;
-    position:absolute;
-    top:50%;
-    left:50%;
-    -webkit-transform:translateY(-50%) translateX(-50%);
-    transform:translateY(-50%) translateX(-50%);
-    width:80%;
-    min-width:900px;
-    max-width:1000px;
-    height:90%;
-    max-height:680px
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translateY(-50%) translateX(-50%);
+  transform: translateY(-50%) translateX(-50%);
+  width: 80%;
+  min-width: 900px;
+  max-width: 1000px;
+  height: 90%;
+  max-height: 680px;
 }
 
 @media (max-width: 975px) {
-    .calendly-overlay .calendly-popup {
-        position:fixed;
-        top:50px;
-        left:0;
-        right:0;
-        bottom:0;
-        -webkit-transform:none;
-        transform:none;
-        width:100%;
-        height:auto;
-        min-width:0;
-        max-height:none
-    }
+  .calendly-overlay .calendly-popup {
+    position: fixed;
+    top: 50px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    -webkit-transform: none;
+    transform: none;
+    width: 100%;
+    height: auto;
+    min-width: 0;
+    max-height: none;
+  }
 }
 
 .calendly-overlay .calendly-popup .calendly-popup-content {
-    height:100%;
+  height: 100%;
 }
 
 .calendly-overlay .calendly-popup-close {
-    position:absolute;
-    top:25px;
-    right:25px;
-    color:#fff;
-    width:19px;
-    height:19px;
-    cursor:pointer;
-    background:url(https://assets.calendly.com/assets/external/close-icon.svg) no-repeat;
-    background-size:contain
+  position: absolute;
+  top: 25px;
+  right: 25px;
+  color: #fff;
+  width: 19px;
+  height: 19px;
+  cursor: pointer;
+  background: url(https://assets.calendly.com/assets/external/close-icon.svg)
+    no-repeat;
+  background-size: contain;
 }
 
 @media (max-width: 975px) {
-    .calendly-overlay .calendly-popup-close {
-        top:15px;
-        right:15px
-    }
+  .calendly-overlay .calendly-popup-close {
+    top: 15px;
+    right: 15px;
+  }
 }
 
 .calendly-badge-widget {
-    position:fixed;
-    right:20px;
-    bottom:15px;
-    z-index:9998
+  position: fixed;
+  right: 20px;
+  bottom: 15px;
+  z-index: 9998;
 }
 
 .calendly-badge-widget .calendly-badge-content {
-    display:table-cell;
-    width:auto;
-    height:45px;
-    padding:0 30px;
-    border-radius:25px;
-    box-shadow:rgba(0,0,0,0.25) 0 2px 5px;
-    font-family:sans-serif;
-    text-align:center;
-    vertical-align:middle;
-    font-weight:bold;
-    font-size:14px;
-    color:#fff;
-    cursor:pointer
+  display: table-cell;
+  width: auto;
+  height: 45px;
+  padding: 0 30px;
+  border-radius: 25px;
+  box-shadow: rgba(0, 0, 0, 0.25) 0 2px 5px;
+  font-family: sans-serif;
+  text-align: center;
+  vertical-align: middle;
+  font-weight: bold;
+  font-size: 14px;
+  color: #fff;
+  cursor: pointer;
 }
 
 .calendly-badge-widget .calendly-badge-content.calendly-white {
-    color:#666a73
+  color: #666a73;
 }
 
 .calendly-badge-widget .calendly-badge-content span {
-    display:block;
-    font-size:12px
+  display: block;
+  font-size: 12px;
 }
 
 .calendly-spinner {
-    position:absolute;
-    top:50%;
-    left:0;
-    right:0;
-    -webkit-transform:translateY(-50%);
-    transform:translateY(-50%);
-    text-align:center;
-    z-index:-1
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  -webkit-transform: translateY(-50%);
+  transform: translateY(-50%);
+  text-align: center;
+  z-index: -1;
 }
 
-.calendly-spinner>div {
-    display:inline-block;
-    width:18px;
-    height:18px;
-    background-color:#e1e1e1;
-    border-radius:50%;
-    vertical-align:middle;
-    -webkit-animation:calendly-bouncedelay 1.4s infinite ease-in-out;
-    animation:calendly-bouncedelay 1.4s infinite ease-in-out;
-    -webkit-animation-fill-mode:both;
-    animation-fill-mode:both
+.calendly-spinner > div {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  background-color: #e1e1e1;
+  border-radius: 50%;
+  vertical-align: middle;
+  -webkit-animation: calendly-bouncedelay 1.4s infinite ease-in-out;
+  animation: calendly-bouncedelay 1.4s infinite ease-in-out;
+  -webkit-animation-fill-mode: both;
+  animation-fill-mode: both;
 }
 
 .calendly-spinner .calendly-bounce1 {
-    -webkit-animation-delay:-0.32s;
-    animation-delay:-0.32s
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
 }
 
 .calendly-spinner .calendly-bounce2 {
-    -webkit-animation-delay:-0.16s;
-    animation-delay:-0.16s
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
 }
 
 @-webkit-keyframes calendly-bouncedelay {
-    0%,80%,100% {
-        -webkit-transform:scale(0);
-        transform:scale(0)
-    } 
-    
-    40%{
-        -webkit-transform:scale(1);
-        transform:scale(1)
-    }
+  0%,
+  80%,
+  100% {
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  }
+
+  40% {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
 }
 
-@keyframes calendly-bouncedelay{ 
-    0%,80%,100% {
-        -webkit-transform:scale(0);
-        transform:scale(0)
-    }
-    
-    40% {
-        -webkit-transform:scale(1);
-        transform:scale(1)
-    }
+@keyframes calendly-bouncedelay {
+  0%,
+  80%,
+  100% {
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  }
+
+  40% {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
 }

--- a/src/calendly.tsx
+++ b/src/calendly.tsx
@@ -9,7 +9,6 @@ export type Prefill = Optional<{
   email: string;
   firstName: string;
   lastName: string;
-  smsReminderNumber: string;
   location: string;
   guests: string[];
   customAnswers: Optional<{
@@ -113,7 +112,7 @@ export const formatCalendlyUrl = ({
     primaryColor,
     textColor,
     hideGdprBanner,
-  } = sanitizedPageSettings
+  } = sanitizedPageSettings;
 
   const {
     customAnswers,
@@ -123,7 +122,6 @@ export const formatCalendlyUrl = ({
     guests,
     lastName,
     location,
-    smsReminderNumber,
     name,
   } = prefill;
 
@@ -150,7 +148,6 @@ export const formatCalendlyUrl = ({
     textColor ? `text_color=${textColor}` : null,
     hideGdprBanner ? `hide_gdpr_banner=1` : null,
     name ? `name=${encodeURIComponent(name)}` : null,
-    smsReminderNumber ? `phone_number=${encodeURIComponent(smsReminderNumber)}` : null,
     location ? `location=${encodeURIComponent(location)}` : null,
     firstName ? `first_name=${encodeURIComponent(firstName)}` : null,
     lastName ? `last_name=${encodeURIComponent(lastName)}` : null,

--- a/src/components/InlineWidget/InlineWidget.tsx
+++ b/src/components/InlineWidget/InlineWidget.tsx
@@ -18,12 +18,15 @@ export interface Props {
   pageSettings?: PageSettings;
   iframeTitle?: IframeTitle;
   LoadingSpinner?: LoadingSpinner;
+  className?: string;
 }
 
 const defaultStyles = {
   minWidth: "320px",
   height: "630px",
 };
+
+const defaultClassName = "calendly-inline-widget";
 
 class InlineWidget extends React.Component<Props, { isLoading: boolean }> {
   constructor(props: Props) {
@@ -54,7 +57,7 @@ class InlineWidget extends React.Component<Props, { isLoading: boolean }> {
 
     return (
       <div
-        className="calendly-inline-widget"
+        className={this.props.className || defaultClassName}
         style={this.props.styles || defaultStyles}
       >
         {this.state.isLoading && <LoadingSpinner />}

--- a/src/components/InlineWidget/InlineWidget.tsx
+++ b/src/components/InlineWidget/InlineWidget.tsx
@@ -21,11 +21,6 @@ export interface Props {
   className?: string;
 }
 
-const defaultStyles = {
-  minWidth: "320px",
-  height: "630px",
-};
-
 const defaultClassName = "calendly-inline-widget";
 
 class InlineWidget extends React.Component<Props, { isLoading: boolean }> {
@@ -58,7 +53,7 @@ class InlineWidget extends React.Component<Props, { isLoading: boolean }> {
     return (
       <div
         className={this.props.className || defaultClassName}
-        style={this.props.styles || defaultStyles}
+        style={this.props.styles || {}}
       >
         {this.state.isLoading && <LoadingSpinner />}
         <iframe


### PR DESCRIPTION
This fork:
- adds support to `InlineWidget` to accept `className` as a prop
- removes the unused `smsReminderNumber` prop 
- updates `README` to remove prop

Taken from #194 and #186