### PR TITLE
Add containerDivProps prop to enable passing props to the container div

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ utm={{
 }}
 ```
 
+#### Additional Container Div Props
+
+Calendly allows you to add a `data-resize` attribute to the container div for inline embeds to enable dynamic height resizing. You can pass this attribute, and any other valid HTML attributes, via the `containerDivProps` prop:
+
+```jsx
+containerDivProps={{
+  "data-resize": "true"
+}}
+```
+
 ## FAQ
 
 #### Why are my page settings not working?

--- a/src/components/InlineWidget/InlineWidget.tsx
+++ b/src/components/InlineWidget/InlineWidget.tsx
@@ -19,6 +19,7 @@ export interface Props {
   iframeTitle?: IframeTitle;
   LoadingSpinner?: LoadingSpinner;
   className?: string;
+  containerDivProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 const defaultClassName = "calendly-inline-widget";
@@ -54,6 +55,7 @@ class InlineWidget extends React.Component<Props, { isLoading: boolean }> {
       <div
         className={this.props.className || defaultClassName}
         style={this.props.styles || {}}
+        {...this.props.containerDivProps}
       >
         {this.state.isLoading && <LoadingSpinner />}
         <iframe


### PR DESCRIPTION
Calendly allows passing `data-resize` to the container div to enable dynamic resizing of the iframe (as explained here: https://help.calendly.com/hc/en-us/articles/31618265722775-Advanced-Calendly-embed-for-developers#h_01JSJ3E1H653K9WSXKGQHVTB0K)

This PR enables the passing this and any other props to the container div in the inline widget.
